### PR TITLE
Bundle cublas lib

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,9 @@ platforms:
 
 apps:
   gpu-burn:
-    command: usr/sbin/gpu-burn -c $SNAP/usr/share/gpu-burn/compare.ptx
+    command: bin/gpu-burn -c $SNAP/usr/share/gpu-burn/compare.ptx
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/local/cuda/lib:$LD_LIBRARY_PATH
     plugs:
       - opengl
       - hardware-observe
@@ -55,17 +57,20 @@ parts:
     source: https://github.com/wilicc/gpu-burn.git
     source-type: git
     source-commit: 9aefd7c0cc603bbc8c3c102f5338c6af26f8127c
-    build-packages: [cuda-toolkit-12-6]
+    build-packages: [cuda-toolkit-12-6, libcublas-12-6]
     stage-packages: [libglu1-mesa]
     override-build: |
       make
 
-      mkdir -p $CRAFT_PART_INSTALL/usr/sbin $CRAFT_PART_INSTALL/usr/share/gpu-burn
+      mkdir -p $CRAFT_PART_INSTALL/bin \
+        $CRAFT_PART_INSTALL/usr/share/gpu-burn \
+        $CRAFT_PART_INSTALL/usr/local/cuda/lib
 
       cp gpu-burn.8 $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       cp LICENSE $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       cp README.md $CRAFT_PART_INSTALL/usr/share/gpu-burn/
-      cp gpu_burn $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       cp compare.ptx $CRAFT_PART_INSTALL/usr/share/gpu-burn/
+      cp gpu_burn $CRAFT_PART_INSTALL/usr/share/gpu-burn/
+      ln -s ../share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/bin/gpu-burn
 
-      ln -s ../share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/usr/sbin/gpu-burn
+      cp /usr/local/cuda/lib64/libcublas* $CRAFT_PART_INSTALL/usr/local/cuda/lib/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,3 +76,10 @@ parts:
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
 
       cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/
+
+lint:
+  ignore:
+    - library:
+      - usr/local/cuda/lib/libcublas.so*
+      - usr/local/cuda/lib/libcublasLt.so*
+      - usr/local/cuda/lib/libcudart.so*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,11 +24,10 @@ platforms:
 apps:
   gpu-burn:
     command: bin/gpu-burn -c $SNAP/usr/share/gpu-burn/compare.ptx
-    extensions: [gnome]
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/local/cuda/lib:$LD_LIBRARY_PATH
+    extensions: [gnome]
     plugs:
-      - opengl
       - hardware-observe
       - network-bind
       - home
@@ -55,7 +54,7 @@ parts:
       - libcublas-12-6
       - cuda-cudart-12-6
     override-build: |
-      make
+      craftctl default
 
       mkdir -p $CRAFT_PART_INSTALL/bin \
         $CRAFT_PART_INSTALL/usr/share/gpu-burn \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,7 @@ parts:
     source-type: git
     source-commit: 9aefd7c0cc603bbc8c3c102f5338c6af26f8127c
     build-packages:
+      - nvidia-utils-550-server
       - cuda-toolkit-12-6
       - libcublas-12-6
       - cuda-cudart-12-6
@@ -73,3 +74,5 @@ parts:
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
       cp /usr/local/cuda/lib64/libcudart* \
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
+
+      cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,6 @@ apps:
     command: bin/gpu-burn -c $SNAP/usr/share/gpu-burn/compare.ptx
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/local/cuda/lib:$LD_LIBRARY_PATH
-    extensions: [gnome]
     plugs:
       - opengl
       - hardware-observe
@@ -44,7 +43,16 @@ package-repositories:
     priority: 600
 
 parts:
+  glib-only:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-type: git
+    source-subdir: glib-only
+    plugin: make
+    build-packages: [libglib2.0-dev]
+    stage-packages: [libglib2.0-bin]
+
   gpu-burn:
+    after: [glib-only]
     plugin: make
     source: https://github.com/wilicc/gpu-burn.git
     source-type: git
@@ -54,6 +62,7 @@ parts:
       - cuda-toolkit-12-6
       - libcublas-12-6
       - cuda-cudart-12-6
+    stage-packages: [libglu1-mesa]
     override-build: |
       make
 
@@ -83,3 +92,4 @@ lint:
       - usr/local/cuda/lib/libcublas.so*
       - usr/local/cuda/lib/libcublasLt.so*
       - usr/local/cuda/lib/libcudart.so*
+      - usr/lib/x86_64-linux-gnu/libGLU.so*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ platforms:
 apps:
   gpu-burn:
     command: bin/gpu-burn -c $SNAP/usr/share/gpu-burn/compare.ptx
+    extensions: [gnome]
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/local/cuda/lib:$LD_LIBRARY_PATH
     plugs:
@@ -43,16 +44,7 @@ package-repositories:
     priority: 600
 
 parts:
-  glib-only:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-type: git
-    source-subdir: glib-only
-    plugin: make
-    build-packages: [libglib2.0-dev]
-    stage-packages: [libglib2.0-bin]
-
   gpu-burn:
-    after: [glib-only]
     plugin: make
     source: https://github.com/wilicc/gpu-burn.git
     source-type: git
@@ -61,7 +53,6 @@ parts:
       - cuda-toolkit-12-6
       - libcublas-12-6
       - cuda-cudart-12-6
-    stage-packages: [libglu1-mesa]
     override-build: |
       make
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,7 +55,7 @@ parts:
       - libcublas-12-6
       - cuda-cudart-12-6
     override-build: |
-      craftctl default
+      make
 
       mkdir -p $CRAFT_PART_INSTALL/bin \
         $CRAFT_PART_INSTALL/usr/share/gpu-burn \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,3 +93,4 @@ lint:
       - usr/local/cuda/lib/libcublasLt.so*
       - usr/local/cuda/lib/libcudart.so*
       - usr/lib/x86_64-linux-gnu/libGLU.so*
+      - usr/lib/x86_64-linux-gnu/libOpenGL.so*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ apps:
       LD_LIBRARY_PATH: $SNAP/usr/local/cuda/lib:$LD_LIBRARY_PATH
     extensions: [gnome]
     plugs:
+      - opengl
       - hardware-observe
       - network-bind
       - home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,10 @@ parts:
     source: https://github.com/wilicc/gpu-burn.git
     source-type: git
     source-commit: 9aefd7c0cc603bbc8c3c102f5338c6af26f8127c
-    build-packages: [cuda-toolkit-12-6, libcublas-12-6]
+    build-packages:
+      - cuda-toolkit-12-6
+      - libcublas-12-6
+      - cuda-cudart-12-6
     stage-packages: [libglu1-mesa]
     override-build: |
       make
@@ -73,4 +76,9 @@ parts:
       cp gpu_burn $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       ln -s ../usr/share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/bin/gpu-burn
 
-      cp /usr/local/cuda/lib64/libcublas* $CRAFT_PART_INSTALL/usr/local/cuda/lib/
+      cp /usr/local/cuda/lib64/libcublas* \
+        $CRAFT_PART_INSTALL/usr/local/cuda/lib/
+      cp /usr/local/cuda/lib64/libcublasLt* \
+        $CRAFT_PART_INSTALL/usr/local/cuda/lib/
+      cp /usr/local/cuda/lib64/libcudart* \
+        $CRAFT_PART_INSTALL/usr/local/cuda/lib/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,6 +71,6 @@ parts:
       cp README.md $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       cp compare.ptx $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       cp gpu_burn $CRAFT_PART_INSTALL/usr/share/gpu-burn/
-      ln -s ../share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/bin/gpu-burn
+      ln -s ../usr/share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/bin/gpu-burn
 
       cp /usr/local/cuda/lib64/libcublas* $CRAFT_PART_INSTALL/usr/local/cuda/lib/


### PR DESCRIPTION
The cublas libraries are not kept up to date across Ubuntu releases. A solution to this problem is to bundle the libraries with the snap.