### PR TITLE
Only bundle needed libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,7 +74,5 @@ parts:
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
       cp -a /usr/local/cuda/lib64/libcublasLt.so* \
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
-      cp -a /usr/lib/x86_64-linux-gnu/libcuda.so* \
-        $CRAFT_PART_INSTALL/usr/local/cuda/lib/
 
       cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,16 +43,7 @@ package-repositories:
     priority: 600
 
 parts:
-  glib-only:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-type: git
-    source-subdir: glib-only
-    plugin: make
-    build-packages: [libglib2.0-dev]
-    stage-packages: [libglib2.0-bin]
-
   gpu-burn:
-    after: [glib-only]
     plugin: make
     source: https://github.com/wilicc/gpu-burn.git
     source-type: git
@@ -61,7 +52,6 @@ parts:
       - nvidia-utils-550-server
       - cuda-toolkit-12-6
       - libcublas-12-6
-    stage-packages: [libglu1-mesa]
     override-pull: |
       craftctl default
       git apply --ignore-space-change --ignore-whitespace \
@@ -86,10 +76,3 @@ parts:
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
 
       cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/
-
-lint:
-  ignore:
-    - library:
-      - usr/lib/x86_64-linux-gnu/libGLU.so*
-      - usr/lib/x86_64-linux-gnu/libOpenGL.so*
-      - usr/lib/x86_64-linux-gnu/libGLdispatch.so*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,5 +74,7 @@ parts:
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
       cp -a /usr/local/cuda/lib64/libcublasLt.so* \
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
+      cp -a /usr/lib/x86_64-linux-gnu/libcuda.so* \
+        $CRAFT_PART_INSTALL/usr/local/cuda/lib/
 
       cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,7 +61,6 @@ parts:
       - nvidia-utils-550-server
       - cuda-toolkit-12-6
       - libcublas-12-6
-      - cuda-cudart-12-6
     stage-packages: [libglu1-mesa]
     override-pull: |
       craftctl default
@@ -81,11 +80,9 @@ parts:
       cp gpu_burn $CRAFT_PART_INSTALL/usr/share/gpu-burn/
       ln -s ../usr/share/gpu-burn/gpu_burn $CRAFT_PART_INSTALL/bin/gpu-burn
 
-      cp -a /usr/local/cuda/lib64/libcublas* \
+      cp -a /usr/local/cuda/lib64/libcublas.so* \
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
-      cp -a /usr/local/cuda/lib64/libcublasLt* \
-        $CRAFT_PART_INSTALL/usr/local/cuda/lib/
-      cp -a /usr/local/cuda/lib64/libcudart* \
+      cp -a /usr/local/cuda/lib64/libcublasLt.so* \
         $CRAFT_PART_INSTALL/usr/local/cuda/lib/
 
       cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/bin/
@@ -93,9 +90,6 @@ parts:
 lint:
   ignore:
     - library:
-      - usr/local/cuda/lib/libcublas.so*
-      - usr/local/cuda/lib/libcublasLt.so*
-      - usr/local/cuda/lib/libcudart.so*
       - usr/lib/x86_64-linux-gnu/libGLU.so*
       - usr/lib/x86_64-linux-gnu/libOpenGL.so*
       - usr/lib/x86_64-linux-gnu/libGLdispatch.so*


### PR DESCRIPTION
Resolves #12 

The snap is quite large mainly because of the libraries that are bundled into it. The linter only recommends the cublas `.so` shared libraries. I don't think cudart or the static libraries are needed in the snap.

If that's the case, this PR halves the snap size.